### PR TITLE
feat: vite support for v2 (tailwind 3+)

### DIFF
--- a/nativescript.vite.mjs
+++ b/nativescript.vite.mjs
@@ -1,0 +1,22 @@
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+
+let postcssConfig = "./postcss.config.js";
+
+try {
+  const tailwind = require("tailwindcss");
+  const nsTailwind = require("@nativescript/tailwind");
+  postcssConfig = { plugins: [tailwind, nsTailwind] };
+} catch (err) {
+  console.warn(
+    "Inline PostCSS unavailable, falling back to ./postcss.config.js"
+  );
+}
+
+export default () => {
+  return {
+    css: {
+      postcss: postcssConfig,
+    },
+  };
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "files": [
     "src",
+    "nativescript.vite.mjs",
     "nativescript.webpack.js"
   ],
   "repository": "https://github.com/NativeScript/tailwind",


### PR DESCRIPTION
- Supports tailwindcss v3.x.x via @nativescript/tailwind 2.x.x
- Can be published as a patch on the 2.x series