### PR TITLE
feat: flatten @supports rules to enable Tailwind v4 opacity modifiers

### DIFF
--- a/src/removeUnsupported.js
+++ b/src/removeUnsupported.js
@@ -46,10 +46,14 @@ module.exports = (options = { debug: false }) => {
         mediaAtRule.remove();
       },
 
-      // remove @supports rules - not supported in NativeScript
-      // Tailwind v4 generates these for browser compatibility
+      // Flatten @supports rules instead of removing them.
+      // NativeScript Core 8.9.1+ supports color-mix() (see NativeScript/NativeScript#10718),
+      // and Tailwind v4 wraps opacity modifier utilities in @supports(color: color-mix(...)).
       supports(supportsAtRule) {
-        supportsAtRule.remove();
+        if (!supportsAtRule.nodes || !supportsAtRule.nodes.length) {
+          return supportsAtRule.remove();
+        }
+        supportsAtRule.replaceWith(...supportsAtRule.nodes);
       },
 
       // remove @property rules


### PR DESCRIPTION
Tailwind v4 wraps color-mix() declarations inside @supports blocks (e.g. bg-primary/50). Since NativeScript Core 8.9.1+ supports color-mix() (https://github.com/NativeScript/NativeScript/pull/10718), we can flatten @supports rules instead of removing them — same approach already used for @layer.

Also removes the placeholder-color + color-mix exclusion, as it's no longer needed.

Requires: @nativescript/core >= 8.9.1